### PR TITLE
Centralize config loading

### DIFF
--- a/astro/embedder.py
+++ b/astro/embedder.py
@@ -1,24 +1,26 @@
 from chromadb.utils.embedding_functions import OpenAIEmbeddingFunction
-from astro.utils import load_config
+from astro.utils import AppConfig
 
-config = load_config()
 
-# APIバージョンなどオプション設定
-embedder_kwargs = {
-    "api_key": config.openai_api_key,
-    "model_name": config.openai_embedding_model,
-}
+def create_embedder(config: AppConfig):
+    """設定から OpenAI 埋め込み関数を初期化する"""
 
-# 任意指定がある場合に追加
-if hasattr(config, "openai_api_base"):
-    embedder_kwargs["api_base"] = config.openai_api_base
-if hasattr(config, "openai_api_type"):
-    embedder_kwargs["api_type"] = config.openai_api_type
-if hasattr(config, "openai_api_version"):
-    embedder_kwargs["api_version"] = config.openai_api_version
+    embedder_kwargs = {
+        "api_key": config.openai_api_key,
+        "model_name": config.openai_embedding_model,
+    }
 
-# 埋め込み関数初期化
-openai_embedder = OpenAIEmbeddingFunction(**embedder_kwargs)
+    # 任意指定がある場合に追加
+    if hasattr(config, "openai_api_base"):
+        embedder_kwargs["api_base"] = config.openai_api_base
+    if hasattr(config, "openai_api_type"):
+        embedder_kwargs["api_type"] = config.openai_api_type
+    if hasattr(config, "openai_api_version"):
+        embedder_kwargs["api_version"] = config.openai_api_version
 
-def embed_text(text: str):
-    return openai_embedder([text])[0]
+    openai_embedder = OpenAIEmbeddingFunction(**embedder_kwargs)
+
+    def embed_text(text: str):
+        return openai_embedder([text])[0]
+
+    return embed_text

--- a/astro/main.py
+++ b/astro/main.py
@@ -7,6 +7,7 @@ import os
 import json
 
 from astro.utils import load_config, load_dotenv_config
+from astro.embedder import create_embedder
 from astro.chroma_client import (
     get_chroma_client,
     query_collection,
@@ -15,12 +16,12 @@ from astro.chroma_client import (
     get_collection_documents,
     get_collection_type
 )
-from astro.embedder import embed_text
 from astro.models import DocumentItem, SchemaDefinition
 
 # ─── 初期化 ───
 load_dotenv_config()
 config = load_config()
+embed_text = create_embedder(config)
 astro = FastAPI()
 chroma_client = get_chroma_client()
 SCHEMA_DIR = Path(config.schema_dir)


### PR DESCRIPTION
## Summary
- load config only in `main.py`
- return embedder init function and use it at startup

## Testing
- `python -m py_compile $(git ls-files '*.py')`