### PR TITLE
Add Docker deployment files and docs

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+__pycache__/
+*.pyc
+*.pyo
+venv/
+.git/
+bearer/*.json

--- a/.env.template
+++ b/.env.template
@@ -16,6 +16,8 @@ ASTRO_API_KEY_DIR="/bearer"
 # ─── 接続先構成（自己の“いる世界WorldConfig”定義）───
 CHROMA_HOST=localhost
 CHROMA_PORT=8000
+# docker compose で起動する場合は以下を利用
+# CHROMA_HOST=chroma
 
 # ─── 知識とは（言葉と規約の通信網）───
 #SaaSじゃない場合はCHROMAもしくは指定されたEMBEDDINGを使用

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,10 @@
+FROM python:3.11-slim
+
+WORKDIR /app
+
+COPY requirements.txt ./
+RUN pip install --no-cache-dir -r requirements.txt
+
+COPY . ./
+
+CMD ["uvicorn", "astro.main:astro", "--host", "0.0.0.0", "--port", "8000"]

--- a/README.md
+++ b/README.md
@@ -87,6 +87,23 @@ pip install -r requirements.txt
 uvicorn astro.main:astro --reload --host 0.0.0.0 --port 8000
 ```
 
+### Docker での起動
+
+Dockerfile と `docker-compose.yml` を用意しています。
+
+#### Docker イメージのビルド
+
+```bash
+docker build -t astro-api .
+docker run --env-file .env -p 8000:8000 astro-api
+```
+
+#### docker compose
+
+```bash
+docker compose up -d
+```
+
 ---
 
 ## 📄 .env 設定例

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,19 @@
+version: '3.8'
+services:
+  chroma:
+    image: ghcr.io/chroma-core/chroma:0.4.24
+    volumes:
+      - chroma-data:/chroma
+    ports:
+      - "8000:8000"
+
+  astro:
+    build: .
+    env_file: .env
+    ports:
+      - "8001:8000"
+    depends_on:
+      - chroma
+
+volumes:
+  chroma-data:

--- a/start.sh
+++ b/start.sh
@@ -1,0 +1,7 @@
+#!/bin/sh
+set -a
+if [ -f .env ]; then
+  . ./.env
+fi
+set +a
+exec uvicorn astro.main:astro --host 0.0.0.0 --port ${PORT:-8000}


### PR DESCRIPTION
## Summary
- add `Dockerfile` to build API service image
- add `.dockerignore` for cleaner builds
- add `docker-compose.yml` with ChromaDB and API
- provide `start.sh` helper script to load `.env`
- update `.env.template` with compose hint
- document Docker usage in README

## Testing
- `python -m py_compile $(git ls-files '*.py')`