### PR TITLE
Implement dynamic schema validation

### DIFF
--- a/astro/chroma_client.py
+++ b/astro/chroma_client.py
@@ -1,13 +1,12 @@
 # app/chroma_client.py
 
 import os
-from typing import List, Sequence, Any
+from typing import List, Sequence, Any, Dict
 
 import chromadb
 from chromadb import AsyncHttpClient
 from chromadb.api.async_client import AsyncClientAPI
 
-from astro.models import DocumentItem
 
 
 # 非同期Chroma HTTPクライアント取得
@@ -33,13 +32,13 @@ async def query_collection(
 async def add_to_collection(
     client: AsyncClientAPI,
     collection: str,
-    items: List[DocumentItem],
+    items: List[Dict[str, Any]],
 ) -> int:
     """ドキュメントをコレクションへ追加する。"""
     coll = await client.get_collection(name=collection)
-    ids = [item.id for item in items]
-    documents = [item.text for item in items]
-    metadatas = [item.metadata or {} for item in items]
+    ids = [str(item.get("id")) for item in items]
+    documents = [json.dumps(item, ensure_ascii=False) for item in items]
+    metadatas = [{k: v for k, v in item.items() if k != "id"} for item in items]
     await coll.add(ids=ids, documents=documents, metadatas=metadatas)
     return len(items)
 

--- a/astro/schema_loader.py
+++ b/astro/schema_loader.py
@@ -1,8 +1,8 @@
 import os
 import json
-from typing import List, Union, Optional,Dict
+from typing import List, Optional, Dict, Any, Type
 from pathlib import Path
-from pydantic import BaseModel
+from pydantic import BaseModel, create_model
 
 
 class FieldDefinition(BaseModel):
@@ -33,3 +33,45 @@ def load_all_schemas(schema_dir: str = "schemas") -> List[SchemaDefinition]:
                 schema = SchemaDefinition(**data)
                 schema_list.append(schema)
     return schema_list
+
+
+def load_schema(collection: str, *, meta_dir: str = "meta", schema_dir: str = "schemas") -> SchemaDefinition:
+    """Load schema definition from meta or schemas directory."""
+    meta_path = Path(meta_dir) / f"{collection}.json"
+    path = meta_path if meta_path.exists() else Path(schema_dir) / f"{collection}.json"
+    if not path.exists():
+        raise FileNotFoundError(f"Schema for {collection} not found")
+    with path.open("r", encoding="utf-8") as f:
+        data = json.load(f)
+    return SchemaDefinition(**data)
+
+
+def save_schema(collection: str, schema: SchemaDefinition, *, meta_dir: str = "meta") -> None:
+    """Persist schema definition for a collection."""
+    Path(meta_dir).mkdir(parents=True, exist_ok=True)
+    path = Path(meta_dir) / f"{collection}.json"
+    with path.open("w", encoding="utf-8") as f:
+        json.dump(schema.model_dump(), f, ensure_ascii=False, indent=2)
+
+
+TYPE_MAP = {
+    "string": str,
+    "integer": int,
+    "int": int,
+    "number": float,
+    "float": float,
+    "boolean": bool,
+    "bool": bool,
+    "object": dict,
+    "array": list,
+}
+
+
+def create_model_from_schema(schema: SchemaDefinition) -> Type[BaseModel]:
+    """Dynamically create a Pydantic model from SchemaDefinition."""
+    fields: Dict[str, tuple[Any, Any]] = {}
+    for field in schema.fields:
+        py_type = TYPE_MAP.get(field.type.lower(), Any)
+        default = ... if field.name in schema.required else None
+        fields[field.name] = (py_type, default)
+    return create_model(f"{schema.name.capitalize()}Model", **fields)


### PR DESCRIPTION
## Summary
- switch to dynamic model generation for add route
- persist collection schema to new `meta/` directory
- expose schema and collection info endpoints
- update HTTP bearer description

## Testing
- `python -m py_compile $(git ls-files '*.py')`

------
https://chatgpt.com/codex/tasks/task_b_683f3d680bfc8322a23b52c9ab0326da